### PR TITLE
Add getNeighbors function

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ The result is
 latitude : 17.38,  longitude : 78.42
 ~~~
 
+Get geohashes of 8 neighbors of a geohash
+~~~
+use Sk\Geohash\Geohash;
+
+$g = new Geohash();
+$hash = $g->encode(25.813646, -80.133761, 7);
+$neighbors = $g->getNeighbors($hash);
+echo "Hash: $hash\n";
+echo "Neighbors: " . json_encode($neighors) . "\n";
+~~~
+The result is
+~~~
+Hash: 
+Neighbors: {"North":"dhx4be2","East":"dhx4be1","South":"dhx4bdb","West":"dhx4b7p","NorthEast":"dhx4be3","SouthEast":"dhx4bdc","SouthWest":"dhx4b6z","NorthWest":"dhx4b7r"}
+~~~
+
 Running the unit tests
 -------
 Go to this directory from your project folder

--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,16 @@
         {
             "name": "Saikiran Ch",
             "email": "saikiranchavan@gmail.com"
+        },{
+            "name": "Chris Raastad",
+            "email": "craastad@gmail.com"
         }
     ],
-    "require": {},
+    "require": {
+        "php": ">=7.0.0"
+    },
     "require-dev": {
-        "phpunit/phpunit": "4.0.*"
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/GeohashTest.php
+++ b/tests/GeohashTest.php
@@ -1,8 +1,9 @@
 <?php
- 
+
+use PHPUnit\Framework\TestCase;
 use Sk\Geohash\Geohash;
  
-class GeohashTest extends PHPUnit_Framework_TestCase
+class GeohashTest extends TestCase
 {
     /**
      * @dataProvider encodeProvider
@@ -55,5 +56,23 @@ class GeohashTest extends PHPUnit_Framework_TestCase
             array(17.385032102, 78.486720398, "tepffhb71hu"),
             array(17.3850320186, 78.48672056569, "tepffhb71hue")
         );
+    }
+
+    public function testGetNeighbors() {
+        $geohash = new Geohash();
+        list($lat1, $lon1) = [25.813646, -80.133761];
+        $hash = $geohash->encode($lat1, $lon1, 7);
+        $neighbors = $geohash->getNeighbors($hash);
+        $this->assertEquals('dhx4be0', $hash);
+        $this->assertEquals([
+            'North' => 'dhx4be2',
+            'East'=> 'dhx4be1',
+            'South' => 'dhx4bdb',
+            'West' => 'dhx4b7p',
+            'NorthEast' => 'dhx4be3',
+            'SouthEast' => 'dhx4bdc',
+            'SouthWest' => 'dhx4b6z',
+            'NorthWest' => 'dhx4b7r',
+        ], $neighbors);
     }
 }


### PR DESCRIPTION
Add getNeighbors function to compute 8 neighbor hashes of a hash.

Code for getNeighbors function was copied from the following library under MIT license.
https://github.com/chency147/geohash/blob/master/src/GeoHash.php#L369-L389

I also upgrade phpunit version to make running phpunit more smooth in dev environment.

I added explicit dependency on PHP 7 in composer to use language specific features.