### PR TITLE
Fix calculate neighbor when lastChar is empty

### DIFF
--- a/src/Geohash.php
+++ b/src/Geohash.php
@@ -144,12 +144,12 @@ class Geohash
      * @param  float   $min
      * @param  float   $max
      * @param  string  $binaryString
-     * @return float   $coordinate   
+     * @return float   $coordinate
      */
     public function getCoordinate($min, $max, $binaryString)
     {
         $error = 0;
-        for ($i = 0; $i < strlen($binaryString); $i++) { 
+        for ($i = 0; $i < strlen($binaryString); $i++) {
             $mid = ($min + $max)/2 ;
             if ($binaryString[$i] == 1){
                 $min = $mid ;
@@ -234,10 +234,6 @@ class Geohash
         if (strpos($this->borderChars[$evenOrOdd][$direction], $lastChar) !== false) {
             $baseHash = $this->calculateNeighbor($baseHash, $direction);
         }
-        if (isset($baseHash{0})) {
-            return $baseHash . $this->neighborChars[$evenOrOdd][$direction]{strpos($this->base32Mapping, $lastChar)};
-        } else {
-            return '';
-        }
+        return $baseHash . $this->neighborChars[$evenOrOdd][$direction]{strpos($this->base32Mapping, $lastChar)};
     }
 }

--- a/tests/GeohashTest.php
+++ b/tests/GeohashTest.php
@@ -2,7 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 use Sk\Geohash\Geohash;
- 
+
 class GeohashTest extends TestCase
 {
     /**
@@ -73,6 +73,54 @@ class GeohashTest extends TestCase
             'SouthEast' => 'dhx4bdc',
             'SouthWest' => 'dhx4b6z',
             'NorthWest' => 'dhx4b7r',
+        ], $neighbors);
+    }
+
+    public function testGetNeighborsGeohash12() {
+        $geohash = new Geohash();
+        $hash = '7j2r6k4z6xtv';
+        $neighbors = $geohash->getNeighbors($hash);
+        $this->assertEquals([
+            'North' => '7j2r6k4z6xty',
+            'East'=> '7j2r6k4z6xwj',
+            'South' => '7j2r6k4z6xtu',
+            'West' => '7j2r6k4z6xtt',
+            'NorthEast' => '7j2r6k4z6xwn',
+            'SouthEast' => '7j2r6k4z6xwh',
+            'SouthWest' => '7j2r6k4z6xts',
+            'NorthWest' => '7j2r6k4z6xtw',
+        ], $neighbors);
+    }
+
+    public function testGetNeighborsGeohash_7j2() {
+        $geohash = new Geohash();
+        $hash = '7j2';
+        $neighbors = $geohash->getNeighbors($hash);
+        $this->assertEquals([
+            'North' => '7j8',
+            'East'=> '7j3',
+            'South' => '7j0',
+            'West' => '6vr',
+            'NorthEast' => '7j9',
+            'SouthEast' => '7j1',
+            'SouthWest' => '6vp',
+            'NorthWest' => '6vx',
+        ], $neighbors);
+    }
+
+    public function testGetNeighborsGeohash_g00() {
+        $geohash = new Geohash();
+        $hash = 'g00';
+        $neighbors = $geohash->getNeighbors($hash);
+        $this->assertEquals([
+            'North' => 'g02',
+            'East'=> 'g01',
+            'South' => 'epb',
+            'West' => 'fbp',
+            'NorthEast' => 'g03',
+            'SouthEast' => 'epc',
+            'SouthWest' => 'dzz',
+            'NorthWest' => 'fbr',
         ], $neighbors);
     }
 }


### PR DESCRIPTION
When the `lastChar` is empty in `calculateNeighbor` function some neighbors are calculated incorrectly. Some cases:

**Geohash 7j2**:

*expected:*
```php
'North' => '7j8'
'East' => '7j3'
'South' => '7j0'
'West' => '6vr'
'NorthEast' => '7j9'
'SouthEast' => '7j1'
'SouthWest' => '6vp'
'NorthWest' => '6vx'
```

*actual:*
```php
'North' => '7j8'
'East' => '7j3'
'South' => '7j0'
'West' => ''
'NorthEast' => '7j9'
'SouthEast' => '7j1'
'SouthWest' => ''
'NorthWest' => ''
```

**Geohash g00**:

*expected:*
```php
'North' => 'g02'
'East' => 'g01'
'South' => 'epb'
'West' => 'fbp'
'NorthEast' => 'g03'
'SouthEast' => 'epc'
'SouthWest' => 'dzz'
'NorthWest' => 'fbr'
```

*actual:*
```php
'North' => 'g02'
'East' => 'g01'
'South' => ''
'West' => ''
'NorthEast' => 'g03'
'SouthEast' => ''
'SouthWest' => ''
'NorthWest' => ''
```